### PR TITLE
Fix failing test

### DIFF
--- a/src/orderbook.rs
+++ b/src/orderbook.rs
@@ -160,7 +160,7 @@ impl OrderBookManager {
             }
             None => {
                 log::warn!("Attempted to replace non-existent order: {:?}", order);
-                Ok(())
+                Err(OrderBookError::NonExistentOrder)
             }
         }
     }


### PR DESCRIPTION
I was messing about with this repo and spotted this test failure

```
test orderbook::tests::test_replace_order ... FAILED

failures:

---- orderbook::tests::test_replace_order stdout ----
thread 'orderbook::tests::test_replace_order' panicked at src/orderbook.rs:740:9:
Expected an error when replacing a non-existent order
```

Hope you can accept this drive-by contribution